### PR TITLE
[Relay][OP] Fix batch matmul quantization implementation

### DIFF
--- a/src/relay/quantize/realize.cc
+++ b/src/relay/quantize/realize.cc
@@ -511,13 +511,14 @@ Expr BatchMatmulRealize(const Call& ref_call, const Array<Expr>& new_args, const
 
   Expr ldata = lhs->data;
   Expr rdata = rhs->data;
-  DataType dtype = cfg->dtype_input;
+  DataType dtype_input = cfg->dtype_input;
+  DataType dtype_weight = cfg->dtype_weight;
 
-  if (lhs->dtype != dtype) {
-    ldata = Cast(ldata, dtype);
+  if (lhs->dtype != dtype_input) {
+    ldata = Cast(ldata, dtype_input);
   }
-  if (rhs->dtype != dtype) {
-    rdata = Cast(rdata, dtype);
+  if (rhs->dtype != dtype_weight) {
+    rdata = Cast(rdata, dtype_weight);
   }
 
   const auto ref_attrs = ref_call->attrs.as<BatchMatmulAttrs>();


### PR DESCRIPTION
Fix a minor problem with batch matmul quantization realize.

If the two inputs are cast into the same data type, no vnni implementation will be added to  batch_matmul x86 strategy.
(In /python/tvm/relay/op/strategy/x86.py, function batch_matmul_strategy_cpu)
