### PR TITLE
Fix AutoTVM int8 vnni dense task extraction problem

### DIFF
--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -130,6 +130,10 @@ def extract_from_multiple_program(mods, params, target, target_host=None, ops=No
             assert isinstance(
                 mod, tvm.IRModule
             ), "only support relay Module or Function to be tuned"
+
+            with target:
+                mod = tvm.relay.transform.AlterOpLayout()(mod)
+
             relay.backend.te_compiler.get().clear()
             # wrap build call in thread to avoid multiprocessing problems
             build_thread = threading.Thread(target=_lower, args=(mod, target, param))

--- a/tests/python/relay/test_autotvm_task_extraction.py
+++ b/tests/python/relay/test_autotvm_task_extraction.py
@@ -121,7 +121,21 @@ def test_task_extraction_for_dense_int8_cuda():
     tasks = autotvm.task.extract_from_program(mod, target=target, params=params, ops=(dense,))
     assert len(tasks) == 1 and tasks[0].name == "dense_int8.cuda"
 
+def test_task_extraction_for_dense_int8_vnni():
+    target = "llvm -mcpu=cascadelake"
+
+    def get_net(batch, in_dim, out_dim, dtype_input, dtype_weight, out_dtype):
+        data = tvm.relay.var("data", shape=[batch, in_dim], dtype=dtype_input)
+        weight = tvm.relay.var("weight", shape=[out_dim, in_dim], dtype=dtype_weight)
+        out = relay.nn.dense(data, weight, out_dtype=out_dtype)
+        mod, params = relay.testing.create_workload(out)
+        return mod, params
+
+    mod, params = get_net(1, 16, 32, "uint8", "int8", "int32")
+    tasks = autotvm.task.extract_from_program(mod, target=target, params=params)
+    assert len(tasks) == 1 and tasks[0].name == "dense_vnni.x86"
 
 if __name__ == "__main__":
     test_task_extraction()
     test_task_extraction_for_dense_int8_cuda()
+    test_task_extraction_for_dense_int8_vnni()

--- a/tests/python/relay/test_autotvm_task_extraction.py
+++ b/tests/python/relay/test_autotvm_task_extraction.py
@@ -121,6 +121,7 @@ def test_task_extraction_for_dense_int8_cuda():
     tasks = autotvm.task.extract_from_program(mod, target=target, params=params, ops=(dense,))
     assert len(tasks) == 1 and tasks[0].name == "dense_int8.cuda"
 
+
 def test_task_extraction_for_dense_int8_vnni():
     target = "llvm -mcpu=cascadelake"
 
@@ -134,6 +135,7 @@ def test_task_extraction_for_dense_int8_vnni():
     mod, params = get_net(1, 16, 32, "uint8", "int8", "int32")
     tasks = autotvm.task.extract_from_program(mod, target=target, params=params)
     assert len(tasks) == 1 and tasks[0].name == "dense_vnni.x86"
+
 
 if __name__ == "__main__":
     test_task_extraction()


### PR DESCRIPTION
This PR is a minor fix on the AutoTVM int8 vnni dense task extraction.
VNNI dense strategy is used only when the input-weight-out datatypes are u8s8s32 and the weight layout is NC16n4c.
Without altering the weight layout, for a simple dense workload:

def @main(%data: Tensor[(1, 16), uint8] /* ty=Tensor[(1, 16), uint8] */, %weight: Tensor[(32, 16), int8] /* ty=Tensor[(32, 16), int8] */) -> Tensor[(1, 32), int32] {
  nn.dense(%data, %weight, units=None, out_dtype="int32") /* ty=Tensor[(1, 32), int32] */
}

There are two non-VNNI tasks extracted:
`
[Task(func_name=dense_nopack.x86, args=(('TENSOR', (1, 16), 'uint8'), ('TENSOR', (32, 16), 'int8'), None, 'int32'), kwargs={}, workload=('dense_nopack.x86', ('TENSOR', (1, 16), 'uint8'), ('TENSOR', (32, 16), 'int8'), None, 'int32')),
`
`
 Task(func_name=dense_pack.x86, args=(('TENSOR', (1, 16), 'uint8'), ('TENSOR', (32, 16), 'int8'), None, 'int32'), kwargs={}, workload=('dense_pack.x86', ('TENSOR', (1, 16), 'uint8'), ('TENSOR', (32, 16), 'int8'), None, 'int32'))]
`

WIth this fix, one VNNI task is extracted:
`
[Task(func_name=dense_vnni.x86, args=(('TENSOR', (1, 16), 'uint8'), ('TENSOR', (2, 4, 16, 4), 'int8'), None, 'int32'), kwargs={}, workload=('dense_vnni.x86', ('TENSOR', (1, 16), 'uint8'), ('TENSOR', (2, 4, 16, 4), 'int8'), None, 'int32'))]
`
